### PR TITLE
Fixed `learning_traj_em_test`

### DIFF
--- a/mm/path_inference/learning_traj_test.py
+++ b/mm/path_inference/learning_traj_test.py
@@ -50,8 +50,8 @@ def simple_traj3():
   """ Simple trajectory with large features, 
   breaks non log-based implementations.
   """
-  features = [ [ [0, 200] ],
-               [ [200, 0], [-100, 0] ],
+  features = [ [ [0., 200.] ],
+               [ [200., 0.], [-100., 0.] ],
              ]
   connections = [ [ (0, 0), (0, 1) ] ]
   traj = LearningTrajectory(features, connections)


### PR DESCRIPTION
Fixed error in `learning_traj_em_test.py`:

```
======================================================================
ERROR: Very simple test: we pick some trajectories and verify that
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\program files (x86)\python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\path_inference\learning_traj_em_test.py", line 35, in test_em_1
    history = learn_em(trajs_estim_obj_fun_1, trajs, theta_start)
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\path_inference\learning_traj_em.py", line 60, in learn_em
    (theta1, ys) = optimize_function(opt_fun, theta, max_inner_iters)
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\path_inference\learning_traj_optimizer.py", line 45, in optimize_function
    (y, g, h) = fun(x)
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\path_inference\learning_traj_optimizer.py", line 204, in inner
    elts.computeGradientValue()
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\path_inference\learning_traj_elements.py", line 120, in computeGradientValue
    self.computeGradientLogZ()
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\path_inference\learning_traj_elements.py", line 855, in computeGradientLogZ
    l_vec[i] = lse_vec(vs)
  File "C:\Users\voidex\Documents\Projects\Path-Inference-Filter\mm\log_math.py", line 94, in lse_vec
    x += exp(norm - norm_max) * v
TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int32') with casting rule 'same_kind'
-------------------- >> begin captured stdout << ---------------------
iter 0, x= [ 0.1  0.1]

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 64 tests in 0.370s

FAILED (errors=1)
```